### PR TITLE
fixed a typo in error catching

### DIFF
--- a/image/main.go
+++ b/image/main.go
@@ -140,8 +140,8 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 
 						jsonByte := (*json.RawMessage)(&jsonMarsh)
 
-						e := json.Unmarshal(*jsonByte, &kservice)
-						if e != nil {
+						err = json.Unmarshal(*jsonByte, &kservice)
+						if err != nil {
 							fmt.Println(err)
 						}
 						endpoint := annotations[ENDPOINT_ANNOTATION_KEY]


### PR DESCRIPTION
In the code, you used the variable "e" to catch and store the error, but you printed the variable "err" which is not the correct variable name. I changed the variable that stores the error to "err" to match the one you printed.
I hope that helps.